### PR TITLE
Release 0.0.1

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,12 @@
 # FFMPEG::ScreenRecorder
 
+### :warning: This gem is not longer maintained. Please use [screen-recorder](https://github.com/kapoorlakshya/screen-recorder) gem :warning:
+<br />
+<br />
+
 [![Gem Version](https://badge.fury.io/rb/ffmpeg-screenrecorder.svg)](https://badge.fury.io/rb/ffmpeg-screenrecorder)
 ![https://rubygems.org/gems/ffmpeg-screenrecorder](https://ruby-gem-downloads-badge.herokuapp.com/ffmpeg-screenrecorder?type=total)
 [![Yard Docs](http://img.shields.io/badge/yard-docs-blue.svg)](https://www.rubydoc.info/github/kapoorlakshya/ffmpeg-screenrecorder/master)
-[![Build Status](https://travis-ci.org/kapoorlakshya/ffmpeg-screenrecorder.svg?branch=master)](https://travis-ci.org/kapoorlakshya/ffmpeg-screenrecorder)
-[![Maintainability](https://api.codeclimate.com/v1/badges/a176dc755e06a23e5db8/maintainability)](https://codeclimate.com/github/kapoorlakshya/ffmpeg-screenrecorder/maintainability)
 
 Ruby gem to record your computer screen - desktop or specific
 application/window - using [FFmpeg](https://www.ffmpeg.org/). Primarily

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # FFMPEG::ScreenRecorder
 
-### :warning: This gem is not longer maintained. Please use [screen-recorder](https://github.com/kapoorlakshya/screen-recorder) gem :warning:
+### :warning: This gem is no longer maintained. Please use [screen-recorder](https://github.com/kapoorlakshya/screen-recorder) gem. :warning:
 <br />
 <br />
 

--- a/ffmpeg-screenrecorder.gemspec
+++ b/ffmpeg-screenrecorder.gemspec
@@ -9,7 +9,7 @@ Gem::Specification.new do |spec|
   spec.email       = ['kapoorlakshya@gmail.com']
   spec.homepage    = 'http://github.com/kapoorlakshya/ffmpeg-screenrecorder'
   spec.summary     = 'Record your computer screen using ffmpeg via Ruby.'
-  spec.description = 'Record your computer screen - desktop or specific application/window - using FFmpeg (https://www.ffmpeg.org).'
+  spec.description = 'Record your computer screen - desktop or specific application/window - using FFmpeg (https://www.ffmpeg.org). NOTE: This gem is not longer maintained. Please use screen-recorder gem.'
   spec.license     = 'MIT'
 
   spec.files = Dir.chdir(File.expand_path(__dir__)) do
@@ -28,7 +28,6 @@ Gem::Specification.new do |spec|
   spec.add_runtime_dependency 'os', '~> 0.9.0'
   spec.add_runtime_dependency 'streamio-ffmpeg', '~> 1.0'
 
-  spec.post_install_message = 'PLEASE NOTE: ffmpeg-screenrecorder will soon be renamed to screen-recorder.\n' \
-  'Please refer to Issue #45 on GitHub for more information ' \
-  '(https://github.com/kapoorlakshya/ffmpeg-screenrecorder/issues/45). Thank you!'
+  spec.post_install_message = 'PLEASE NOTE: ffmpeg-screenrecorder gem has been re-released as screen-recorder gem.\n' \
+  'This gem will no longer be maintained. Thank you!'
 end

--- a/lib/ffmpeg/version.rb
+++ b/lib/ffmpeg/version.rb
@@ -1,5 +1,5 @@
 module FFMPEG
   class ScreenRecorder
-    VERSION = '1.0.0.beta13'.freeze
+    VERSION = '0.0.1'.freeze
   end
 end


### PR DESCRIPTION
- Add deprecation warning in gemspec and README.
- Release v0.0.1 so the Homepage link can be visible on RubyGems website. Beta releases do not show the homepage URL.